### PR TITLE
Naming of various steps

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -44,48 +44,26 @@ jobs:
            bison flex libncurses5-dev libssl-dev bc cpio rsync cmake \
            libgtk-3-0 xz-utils libgmp-dev libmpc-dev bootgen-xlnx
       
-    - name: Cache toolchain
+    - name: Cache toolchain/linux/lib/linux_driver and u-boot-xlnx
       id: cache-toolchain
       uses: actions/cache@v4
       with:
-        path: /home/runner/work/plutosdr-fw/plutosdr-fw/buildroot
+        path: |
+          /home/runner/work/plutosdr-fw/plutosdr-fw/buildroot
+          /home/runner/work/plutosdr-fw/plutosdr-fw/lib
+          /home/runner/work/plutosdr-fw/plutosdr-fw/linux
+          /home/runner/work/plutosdr-fw/plutosdr-fw/linux_driver
+          /home/runner/work/plutosdr-fw/plutosdr-fw/u-boot-xlnx
         key: fw-cache-toolchain
-        
-    - name: Cache linux
-      id: cache-linux
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/work/plutosdr-fw/plutosdr-fw/linux
-        key: fw-cache-linux
-
-    - name: Cache lib
-      id: cache-lib
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/work/plutosdr-fw/plutosdr-fw/lib
-        key: fw-cache-lib
-
-    - name: Cache linux_driver
-      id: cache-linux_driver
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/work/plutosdr-fw/plutosdr-fw/linux_driver
-        key: fw-cache-linux_driver
-
-    - name: Cache u-boot-xlnx
-      id: cache-u-boot-xlnx
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/work/plutosdr-fw/plutosdr-fw/u-boot-xlnx
-        key: fw-cache-u-boot-xlnx
-          
+                  
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
       name: Build PlutoDatvFirmware first build
       run: |
         make 
         TARGET=plutoplus make
         TARGET=e200 make 
-
+        
+    - if: ${{ steps.cache-toolchain.outputs.cache-hit == 'true' }}
     - name: Build PlutoDatvFirmware from cache
       run: |
         make 

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -19,8 +19,8 @@ env:
   VERSION: ${{ inputs.version }}
 jobs:
   build-x86_64:
-    runs-on: self-hosted
-    # runs-on: ubuntu-latest
+    # runs-on: self-hosted
+    runs-on: ubuntu-latest
     # environment: plutosdr-fw-ci
     permissions: write-all
     
@@ -55,6 +55,20 @@ jobs:
       with:
         path: /home/runner/work/plutosdr-fw/plutosdr-fw/linux
         key: fw-cache-linux
+
+    - name: Cache lib
+      id: cache-lib
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/work/plutosdr-fw/plutosdr-fw/lib
+        key: fw-cache-lib
+
+    - name: Cache linux_driver
+      id: cache-linux_driver
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/work/plutosdr-fw/plutosdr-fw/linux_driver
+        key: fw-cache-linux_driver
 
     - name: Cache u-boot-xlnx
       id: cache-u-boot-xlnx

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -44,27 +44,50 @@ jobs:
            bison flex libncurses5-dev libssl-dev bc cpio rsync cmake \
            libgtk-3-0 xz-utils libgmp-dev libmpc-dev bootgen-xlnx
       
-    - name: Cache toolchain/linux/lib/linux_driver and u-boot-xlnx
+    - name: Cache toolchain
       id: cache-toolchain
       uses: actions/cache@v4
       with:
-        path: |
-          /home/runner/work/plutosdr-fw/plutosdr-fw/buildroot
-          /home/runner/work/plutosdr-fw/plutosdr-fw/lib
-          /home/runner/work/plutosdr-fw/plutosdr-fw/linux
-          /home/runner/work/plutosdr-fw/plutosdr-fw/linux_driver
-          /home/runner/work/plutosdr-fw/plutosdr-fw/u-boot-xlnx
+        path: /home/runner/work/plutosdr-fw/plutosdr-fw/buildroot
         key: fw-cache-toolchain
-                  
+        
+    - name: Cache linux
+      id: cache-linux
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/work/plutosdr-fw/plutosdr-fw/linux
+        key: fw-cache-linux
+
+    - name: Cache lib
+      id: cache-lib
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/work/plutosdr-fw/plutosdr-fw/lib
+        key: fw-cache-lib
+
+    - name: Cache linux_driver
+      id: cache-linux_driver
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/work/plutosdr-fw/plutosdr-fw/linux_driver
+        key: fw-cache-linux_driver
+
+    - name: Cache u-boot-xlnx
+      id: cache-u-boot-xlnx
+      uses: actions/cache@v4
+      with:
+        path: /home/runner/work/plutosdr-fw/plutosdr-fw/u-boot-xlnx
+        key: fw-cache-u-boot-xlnx
+          
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
       name: Build PlutoDatvFirmware first build
       run: |
         make 
         TARGET=plutoplus make
         TARGET=e200 make 
-        
+
     - if: ${{ steps.cache-toolchain.outputs.cache-hit == 'true' }}
-    - name: Build PlutoDatvFirmware from cache
+      name: Build PlutoDatvFirmware from cache
       run: |
         make 
         TARGET=plutoplus make

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -19,8 +19,8 @@ env:
   VERSION: ${{ inputs.version }}
 jobs:
   build-x86_64:
-    # runs-on: self-hosted
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+    # runs-on: ubuntu-latest
     # environment: plutosdr-fw-ci
     permissions: write-all
     

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -18,7 +18,7 @@ on:
 env:
   VERSION: ${{ inputs.version }}
 
-run-name: Build plutosdr-fw run ${{ github.run_number }}
+run-name: Build plutosdr-fw run for tag - PlutoDVB2_${{ inputs.version }}
 jobs:
   build-x86_64:
     # runs-on: self-hosted

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -17,6 +17,8 @@ on:
     
 env:
   VERSION: ${{ inputs.version }}
+
+run-name: Build plutosdr-fw run ${{ github.run_number }}
 jobs:
   build-x86_64:
     # runs-on: self-hosted
@@ -78,13 +80,13 @@ jobs:
         key: fw-cache-u-boot-xlnx
           
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
-      name: Build PlutoDatvFirmware - no cache found
+      name: Build PlutoDatvFirmware first build
       run: |
         make 
         TARGET=plutoplus make
         TARGET=e200 make 
 
-    - name: cache found
+    - name: Build PlutoDatvFirmware from cache
       run: |
         make 
         TARGET=plutoplus make


### PR DESCRIPTION
Caching of `lib` and `linux_driver`
- Fix bug that builds `cached run` on first run
- Name the runs according to `Build plutosdr-fw run for tag - PlutoDVB2_${{ inputs.version }}`
![image](https://github.com/F5OEO/plutosdr-fw/assets/26934113/de032fbc-2b02-44bd-9d0d-0c9650691b41)
