### PR TITLE
Update S50gpsd - add cp210x override if present

### DIFF
--- a/datv/board/pluto/overlay/etc/init.d/S50gpsd
+++ b/datv/board/pluto/overlay/etc/init.d/S50gpsd
@@ -9,7 +9,7 @@ NAME=gpsd
 DAEMON=/usr/sbin/$NAME
 if [[ $SERIAL ]]; then
     if ! [ -L /dev/ttyACM0 ]; then
-        #ln -s /dev/$SERIAL /dev/ttyACM0
+        ln -s /dev/$SERIAL /dev/ttyACM0
         echo "symlinked - /dev/$SERIAL"
     else
         echo "Already symlinked - /dev/$SERIAL"

--- a/datv/board/pluto/overlay/etc/init.d/S50gpsd
+++ b/datv/board/pluto/overlay/etc/init.d/S50gpsd
@@ -8,7 +8,7 @@ DAEMON=/usr/sbin/$NAME
 DEVICES="/dev/ttyACM0"
 PIDFILE=/var/run/$NAME.pid
 GPSD_OPTIONS="-G -n -r"
-GPSCTL_OPTIONS="-n"
+GPSCTL_OPTIONS="--nmea"
 
 #################################################
 # FIND GPS USB SERIAL DEVICE  - CP210x - MTK-3301 
@@ -26,7 +26,7 @@ if [[ $SERIAL ]]; then
     # return only $GNZDA
     # eval $CMD
     GPSD_OPTIONS="-G -n -r -s 9600"
-    GPSCTL_OPTIONS="-n -s 9600"
+    GPSCTL_OPTIONS="--nmea -s 9600"
     echo "GPS options set for /dev/$SERIAL"
 fi
 #################################################

--- a/datv/board/pluto/overlay/etc/init.d/S50gpsd
+++ b/datv/board/pluto/overlay/etc/init.d/S50gpsd
@@ -3,8 +3,14 @@
 # Starts the gps daemon.
 #
 
+# FIND GPS USB SERIAL DEVICE  
+SERIAL=$(dmesg | grep 'cp210x' | awk '{print substr($0,length($0)-6,8)}' | tail -1)
 NAME=gpsd
 DAEMON=/usr/sbin/$NAME
+if [[ $SERIAL ]]; then
+    ln -s /dev/$SERIAL /dev/ttyACM0
+    echo "symlinked - /dev/$SERIAL"    
+fi
 DEVICES="/dev/ttyACM0"
 PIDFILE=/var/run/$NAME.pid
 GPSD_OPTIONS="-G -n -r"

--- a/datv/board/pluto/overlay/etc/init.d/S50gpsd
+++ b/datv/board/pluto/overlay/etc/init.d/S50gpsd
@@ -8,8 +8,12 @@ SERIAL=$(dmesg | grep 'cp210x' | awk '{print substr($0,length($0)-6,8)}' | tail 
 NAME=gpsd
 DAEMON=/usr/sbin/$NAME
 if [[ $SERIAL ]]; then
-    ln -s /dev/$SERIAL /dev/ttyACM0
-    echo "symlinked - /dev/$SERIAL"    
+    if ! [ -L /dev/ttyACM0 ]; then
+        #ln -s /dev/$SERIAL /dev/ttyACM0
+        echo "symlinked - /dev/$SERIAL"
+    else
+        echo "Already symlinked - /dev/$SERIAL"
+    fi
 fi
 DEVICES="/dev/ttyACM0"
 PIDFILE=/var/run/$NAME.pid

--- a/datv/board/pluto/overlay/etc/init.d/S50gpsd
+++ b/datv/board/pluto/overlay/etc/init.d/S50gpsd
@@ -3,21 +3,30 @@
 # Starts the gps daemon.
 #
 
-# FIND GPS USB SERIAL DEVICE  
-SERIAL=$(dmesg | grep 'cp210x' | awk '{print substr($0,length($0)-6,8)}' | tail -1)
 NAME=gpsd
 DAEMON=/usr/sbin/$NAME
+DEVICES="/dev/ttyACM0"
+PIDFILE=/var/run/$NAME.pid
+GPSD_OPTIONS="-G -n -r"
+
+#################################################
+# FIND GPS USB SERIAL DEVICE  - CP210x - MTK-3301 
+# AXN_5.10_3333_17072500, 0001, Quectel-L76B, 1.0
+#################################################
+SERIAL=$(dmesg | grep 'cp210x' | awk '{print substr($0,length($0)-6,8)}' | tail -1)
 if [[ $SERIAL ]]; then
     if ! [ -L /dev/ttyACM0 ]; then
         ln -s /dev/$SERIAL /dev/ttyACM0
         echo "symlinked - /dev/$SERIAL"
+        gpsctl -s 115200
+        GPSD_OPTIONS="-G -n -r -s 115200"
     else
         echo "Already symlinked - /dev/$SERIAL"
+        gpsctl -s 115200
+        GPSD_OPTIONS="-G -n -r -s 115200"
     fi
 fi
-DEVICES="/dev/ttyACM0"
-PIDFILE=/var/run/$NAME.pid
-GPSD_OPTIONS="-G -n -r"
+#################################################
 
 start() {
         printf "Starting $NAME: "

--- a/datv/board/pluto/overlay/etc/init.d/S50gpsd
+++ b/datv/board/pluto/overlay/etc/init.d/S50gpsd
@@ -8,6 +8,7 @@ DAEMON=/usr/sbin/$NAME
 DEVICES="/dev/ttyACM0"
 PIDFILE=/var/run/$NAME.pid
 GPSD_OPTIONS="-G -n -r"
+GPSCTL_OPTIONS="-n"
 
 #################################################
 # FIND GPS USB SERIAL DEVICE  - CP210x - MTK-3301 
@@ -18,21 +19,23 @@ if [[ $SERIAL ]]; then
     if ! [ -L /dev/ttyACM0 ]; then
         ln -s /dev/$SERIAL /dev/ttyACM0
         echo "symlinked - /dev/$SERIAL"
-        gpsctl -s 115200
-        GPSD_OPTIONS="-G -n -r -s 115200"
     else
         echo "Already symlinked - /dev/$SERIAL"
-        gpsctl -s 115200
-        GPSD_OPTIONS="-G -n -r -s 115200"
     fi
+    # CMD=$(echo -ne "'$PMTK314,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0*29\r\n'" > /dev/$SERIAL)
+    # return only $GNZDA
+    # eval $CMD
+    GPSD_OPTIONS="-G -n -r -s 9600"
+    GPSCTL_OPTIONS="-n -s 9600"
+    echo "GPS options set for /dev/$SERIAL"
 fi
 #################################################
-
+    
 start() {
         printf "Starting $NAME: "
         start-stop-daemon -S -q -p $PIDFILE --exec $DAEMON -- -P $PIDFILE $DEVICES $GPSD_OPTIONS && echo "OK" || echo "Failed"
         sleep 3
-        gpsctl --nmea 
+        gpsctl $GPSCTL_OPTIONS
 }
 stop() {
         printf "Stopping $NAME: "


### PR DESCRIPTION
If the device is present on script start, it creates a symbolic link to `/dev/ttyACM0`